### PR TITLE
Fix MAUI project build settings

### DIFF
--- a/ngPost-MAUI-Blazor-Final/ngPost.MAUI/ngPost.MAUI.csproj
+++ b/ngPost-MAUI-Blazor-Final/ngPost.MAUI/ngPost.MAUI.csproj
@@ -15,6 +15,8 @@
 
 		<OutputType>Exe</OutputType>
 		<RootNamespace>ngPost.MAUI</RootNamespace>
+                <WindowsPackageType>Win32</WindowsPackageType>
+                <EnableWindowsTargeting>true</EnableWindowsTargeting>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- adjust .csproj to define Windows packaging type
- enable cross-target build support

## Testing
- `dotnet workload restore` *(fails: `wasi-experimental` workload issues)*
- `dotnet restore -p:EnableWindowsTargeting=true` *(fails: `NETSDK1147` workload error)*

------
https://chatgpt.com/codex/tasks/task_e_6877df7a337c832d839c278be854e679