### PR TITLE
Fix web build targets

### DIFF
--- a/ngPost-MAUI-Blazor-Final/ngPost.MAUI/Components/Pages/ServerConfig.razor
+++ b/ngPost-MAUI-Blazor-Final/ngPost.MAUI/Components/Pages/ServerConfig.razor
@@ -22,13 +22,13 @@
             @foreach (var server in ViewModel.Servers)
             {
                 <tr>
-                    <td><input type="text" @bind="@server.Host" @onchange="@(() => ViewModel.SaveServersCommand.Execute(null))" /></td>
-                    <td><input type="number" @bind="@server.Port" @onchange="@(() => ViewModel.SaveServersCommand.Execute(null))" /></td>
-                    <td><input type="checkbox" @bind="@server.SslEnabled" @onchange="@(() => ViewModel.SaveServersCommand.Execute(null))" /></td>
-                    <td><input type="number" @bind="@server.Connections" @onchange="@(() => ViewModel.SaveServersCommand.Execute(null))" /></td>
-                    <td><input type="text" @bind="@server.Username" @onchange="@(() => ViewModel.SaveServersCommand.Execute(null))" /></td>
-                    <td><input type="password" @bind="@server.Password" @onchange="@(() => ViewModel.SaveServersCommand.Execute(null))" /></td>
-                    <td><input type="checkbox" @bind="@server.IsEnabled" @onchange="@(() => ViewModel.SaveServersCommand.Execute(null))" /></td>
+                    <td><input type="text" @bind="@server.Host" /></td>
+                    <td><input type="number" @bind="@server.Port" /></td>
+                    <td><input type="checkbox" @bind="@server.SslEnabled" /></td>
+                    <td><input type="number" @bind="@server.Connections" /></td>
+                    <td><input type="text" @bind="@server.Username" /></td>
+                    <td><input type="password" @bind="@server.Password" /></td>
+                    <td><input type="checkbox" @bind="@server.IsEnabled" /></td>
                     <td class="server-actions">
                         <button @onclick="@(() => ViewModel.TestConnectionCommand.Execute(server))">Test</button>
                         <button @onclick="@(() => ViewModel.RemoveServerCommand.Execute(server))">Remove</button>

--- a/ngPost-MAUI-Blazor-Final/ngPost.MAUI/Directory.Build.props
+++ b/ngPost-MAUI-Blazor-Final/ngPost.MAUI/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <UsingMicrosoftNETSdkWeb>true</UsingMicrosoftNETSdkWeb>
+  </PropertyGroup>
+</Project>

--- a/ngPost-MAUI-Blazor-Final/ngPost.MAUI/Services/NntpService.cs
+++ b/ngPost-MAUI-Blazor-Final/ngPost.MAUI/Services/NntpService.cs
@@ -105,7 +105,7 @@ public class NntpService : INntpService
         return Task.CompletedTask;
     }
 
-    private void AddLogEntry(string message, LogLevel level = LogLevel.Info)
+    private void AddLogEntry(string message, Models.LogLevel level = Models.LogLevel.Info)
     {
         var entry = new LogEntry(message, level);
         _logQueue.Enqueue(entry);

--- a/ngPost-MAUI-Blazor-Final/ngPost.MAUI/_Imports.razor
+++ b/ngPost-MAUI-Blazor-Final/ngPost.MAUI/_Imports.razor
@@ -2,4 +2,5 @@
 @using ngPost.MAUI.ViewModels
 @using ngPost.MAUI.Services
 @using ngPost.MAUI.Models
+@using Microsoft.AspNetCore.Components.Routing
 

--- a/ngPost-MAUI-Blazor-Final/ngPost.MAUI/ngPost.MAUI.csproj
+++ b/ngPost-MAUI-Blazor-Final/ngPost.MAUI/ngPost.MAUI.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-windows10.0.19041.0;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+                <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+                <MauiVersion>8.0.0</MauiVersion>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 
@@ -14,8 +14,13 @@
 		<!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
 
 		<OutputType>Exe</OutputType>
-		<RootNamespace>ngPost.MAUI</RootNamespace>
-		<UseMaui>true</UseMaui>
+                <RootNamespace>ngPost.MAUI</RootNamespace>
+                <!-- Avoid MSIX requirement when no AppxManifest is provided -->
+                <WindowsPackageType>None</WindowsPackageType>
+                <EnableWindowsTargeting>true</EnableWindowsTargeting>
+                <!-- Enable web SDK features for BlazorWebView -->
+                <UsingMicrosoftNETSdkWeb>true</UsingMicrosoftNETSdkWeb>
+                <UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- use Microsoft.NET.Sdk with `UsingMicrosoftNETSdkWeb` property
- pin MAUI version and remove MacCatalyst target
- allow Router/NavLink components
- remove duplicate `onchange` handlers
- disambiguate `LogLevel`
- set `UsingMicrosoftNETSdkWeb` in Directory.Build.props so static web asset targets load

## Testing
- `dotnet restore`
- `dotnet build -f net8.0-windows10.0.19041.0 -c Release` *(fails: missing MAUI workloads)*
- `dotnet run -f net8.0-windows10.0.19041.0` *(fails: missing MAUI workloads)*

------
https://chatgpt.com/codex/tasks/task_e_6877df7a337c832d839c278be854e679